### PR TITLE
Fix compatibility with nette/application 3.2.3

### DIFF
--- a/.github/workflows/coding-style.yaml
+++ b/.github/workflows/coding-style.yaml
@@ -1,0 +1,21 @@
+name: Coding style
+
+on: 
+  - push
+  - pull_request
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    name: PHP
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+
+      - run: composer install --no-progress --prefer-dist
+
+      - run: composer cs

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 bin/*
 tests/_output
 tests/Support/_generated
+.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,6 +11,8 @@ return (new Config())
 		'@PHP81Migration' => true,
 		'@PHP80Migration:risky' => true,
 		'@Symfony' => true,
+		'phpdoc_to_param_type' => true,
+		'phpdoc_to_return_type' => true,
 		// Override some Symfony rules.
 		'braces_position' => [
 			'functions_opening_brace' => 'same_line',

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+return (new Config())
+	->setRiskyAllowed(true)
+	->setRules([
+		'@Symfony' => true,
+		// Override some Symfony rules.
+		'braces_position' => [
+			'functions_opening_brace' => 'same_line',
+			'classes_opening_brace' => 'same_line',
+		],
+		'concat_space' => ['spacing' => 'one'],
+		'no_null_property_initialization' => false,
+		'yoda_style' => false,
+	])
+		->setIndent("\t")
+	->setFinder(
+		(new Finder())
+			->ignoreDotFiles(false)
+			->ignoreVCSIgnored(true)
+			->in(__DIR__)
+	)
+;

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,6 +8,8 @@ use PhpCsFixer\Finder;
 return (new Config())
 	->setRiskyAllowed(true)
 	->setRules([
+		'@PHP81Migration' => true,
+		'@PHP80Migration:risky' => true,
 		'@Symfony' => true,
 		// Override some Symfony rules.
 		'braces_position' => [

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,6 +12,7 @@ return (new Config())
 		'@PHP80Migration:risky' => true,
 		'@Symfony' => true,
 		'phpdoc_to_param_type' => true,
+		'phpdoc_to_property_type' => true,
 		'phpdoc_to_return_type' => true,
 		// Override some Symfony rules.
 		'braces_position' => [

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
 	"type": "library",
 	"desc": "Testing helpers for nette presenters and components",
 	"require-dev": {
-		"codeception/codeception": "^5.0",
-		"nette/application": "^3.2",
-		"nette/forms": "^3.1.12",
+		"codeception/codeception": "^5.0.0",
+		"codeception/module-asserts": "^3.0",
 		"latte/latte": "^3.0",
-		"codeception/module-asserts": "^3.0"
+		"nette/application": "^3.2",
+		"nette/forms": "^3.1.12"
 	},
 	"require": {
 		"php": ">= 8.0"
@@ -30,5 +30,8 @@
 		"tests": "vendor/bin/codecept run",
 		"stan": "vendor/bin/phpstan analyse src --level=3 --ansi --no-progress"
 	},
-	"minimum-stability": "RC"
+	"minimum-stability": "RC",
+	"config": {
+		"sort-packages": true
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 	"require-dev": {
 		"codeception/codeception": "^5.0.0",
 		"codeception/module-asserts": "^3.0",
+		"friendsofphp/php-cs-fixer": "^3.56",
 		"latte/latte": "^3.0",
 		"nette/application": "^3.2",
 		"nette/forms": "^3.1.12"
@@ -27,6 +28,8 @@
 		}
 	},
 	"scripts": {
+		"cs": "php-cs-fixer fix --verbose --dry-run --diff",
+		"fix": "php-cs-fixer fix --verbose --diff",
 		"tests": "vendor/bin/codecept run",
 		"stan": "vendor/bin/phpstan analyse src --level=3 --ansi --no-progress"
 	},

--- a/src/Components/Control.php
+++ b/src/Components/Control.php
@@ -8,8 +8,7 @@ use Nette\ComponentModel\IComponent;
 use WebChemistry\Testing\Components\Requests\ControlRequest;
 
 class Control {
-	/** @var PresenterFactory */
-	private $presenterFactory;
+	private PresenterFactory $presenterFactory;
 
 	public function __construct() {
 		$this->presenterFactory = new PresenterFactory();

--- a/src/Components/Control.php
+++ b/src/Components/Control.php
@@ -7,15 +7,15 @@ use WebChemistry\Testing\Components\Requests\ControlRequest;
 
 class Control {
 
-	/** @var Presenter */
-	private $presenter;
+	/** @var PresenterFactory */
+	private $presenterFactory;
 
 	public function __construct() {
-		$this->presenter = new Presenter();
+		$this->presenterFactory = new PresenterFactory();
 	}
 
 	public function createRequest(IComponent $control, string $name = 'control'): ControlRequest {
-		return new ControlRequest($this->presenter, $control, $name);
+		return new ControlRequest($this->presenterFactory, $control, $name);
 	}
 
 }

--- a/src/Components/Control.php
+++ b/src/Components/Control.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components;
 
@@ -6,7 +8,6 @@ use Nette\ComponentModel\IComponent;
 use WebChemistry\Testing\Components\Requests\ControlRequest;
 
 class Control {
-
 	/** @var PresenterFactory */
 	private $presenterFactory;
 
@@ -17,5 +18,4 @@ class Control {
 	public function createRequest(IComponent $control, string $name = 'control'): ControlRequest {
 		return new ControlRequest($this->presenterFactory, $control, $name);
 	}
-
 }

--- a/src/Components/FileSystem.php
+++ b/src/Components/FileSystem.php
@@ -1,13 +1,12 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components;
 
 class FileSystem {
-
 	/**
-	 * Removes directory $dir (including) and sub-directories if contains
-	 *
-	 * @param string $dir
+	 * Removes directory $dir (including) and sub-directories if contains.
 	 */
 	public function removeDirRecursive(string $dir): void {
 		$this->rmDir($dir);
@@ -15,9 +14,6 @@ class FileSystem {
 
 	/**
 	 * Returns count of directories, files, ... without . and ..
-	 *
-	 * @param string $dir
-	 * @return int
 	 */
 	public function itemCount(string $dir): int {
 		$objects = scandir($dir);
@@ -26,16 +22,17 @@ class FileSystem {
 			if ($object === '.' || $object === '..') {
 				continue;
 			}
-			$count++;
+			++$count;
 		}
 
 		return $count;
 	}
 
 	/**
-	 * Returns count of files
+	 * Returns count of files.
 	 *
 	 * @param string $dir
+	 *
 	 * @return int
 	 */
 	public function fileCount($dir) {
@@ -46,7 +43,7 @@ class FileSystem {
 				continue;
 			}
 			if (is_file($dir . '/' . $object)) {
-				$count++;
+				++$count;
 			}
 		}
 
@@ -54,10 +51,7 @@ class FileSystem {
 	}
 
 	/**
-	 * Returns count of directories
-	 *
-	 * @param string $dir
-	 * @return int
+	 * Returns count of directories.
 	 */
 	public function dirCount(string $dir): int {
 		$objects = scandir($dir);
@@ -67,7 +61,7 @@ class FileSystem {
 				continue;
 			}
 			if (is_dir($dir . '/' . $object)) {
-				$count++;
+				++$count;
 			}
 		}
 
@@ -89,5 +83,4 @@ class FileSystem {
 			rmdir($dir);
 		}
 	}
-
 }

--- a/src/Components/FileSystem.php
+++ b/src/Components/FileSystem.php
@@ -30,12 +30,8 @@ class FileSystem {
 
 	/**
 	 * Returns count of files.
-	 *
-	 * @param string $dir
-	 *
-	 * @return int
 	 */
-	public function fileCount($dir) {
+	public function fileCount(string $dir): int {
 		$objects = scandir($dir);
 		$count = 0;
 		foreach ($objects as $object) {

--- a/src/Components/Form.php
+++ b/src/Components/Form.php
@@ -1,15 +1,16 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components;
 
 use Nette\Application\IPresenter;
+use Nette\Application\UI;
 use Nette\ComponentModel\IContainer;
 use WebChemistry\Testing\Components\Presenters\FormPresenter;
 use WebChemistry\Testing\Components\Requests\FormRequest;
-use Nette\Application\UI;
 
 class Form {
-
 	/** @var IPresenter|IContainer */
 	private $presenter;
 
@@ -24,5 +25,4 @@ class Form {
 	public function createRequest(UI\Form $form, string $name = 'form'): FormRequest {
 		return new FormRequest($this->presenterFactory, $form, $name);
 	}
-
 }

--- a/src/Components/Form.php
+++ b/src/Components/Form.php
@@ -11,11 +11,9 @@ use WebChemistry\Testing\Components\Presenters\FormPresenter;
 use WebChemistry\Testing\Components\Requests\FormRequest;
 
 class Form {
-	/** @var IPresenter|IContainer */
-	private $presenter;
+	private IPresenter|IContainer $presenter;
 
-	/** @var PresenterFactory */
-	private $presenterFactory;
+	private PresenterFactory $presenterFactory;
 
 	public function __construct() {
 		$this->presenterFactory = new PresenterFactory();

--- a/src/Components/Form.php
+++ b/src/Components/Form.php
@@ -13,16 +13,16 @@ class Form {
 	/** @var IPresenter|IContainer */
 	private $presenter;
 
-	/** @var Presenter */
-	private $presenters;
+	/** @var PresenterFactory */
+	private $presenterFactory;
 
 	public function __construct() {
-		$this->presenters = new Presenter();
-		$this->presenter = $this->presenters->createPresenter(FormPresenter::class);
+		$this->presenterFactory = new PresenterFactory();
+		$this->presenter = $this->presenterFactory->createPresenter(FormPresenter::class);
 	}
 
 	public function createRequest(UI\Form $form, string $name = 'form'): FormRequest {
-		return new FormRequest($this->presenters, $form, $name);
+		return new FormRequest($this->presenterFactory, $form, $name);
 	}
 
 }

--- a/src/Components/Helpers/Helpers.php
+++ b/src/Components/Helpers/Helpers.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace WebChemistry\Testing\Components\Helpers;
 
 class Helpers {
-	public static function analyzeParams(array &$params, string $controlName) {
+	public static function analyzeParams(array &$params, string $controlName): void {
 		if (!$controlName) {
 			return;
 		}

--- a/src/Components/Helpers/Helpers.php
+++ b/src/Components/Helpers/Helpers.php
@@ -1,9 +1,10 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Helpers;
 
 class Helpers {
-
 	public static function analyzeParams(array &$params, string $controlName) {
 		if (!$controlName) {
 			return;
@@ -16,5 +17,4 @@ class Helpers {
 			}
 		}
 	}
-
 }

--- a/src/Components/Helpers/LatteFactory.php
+++ b/src/Components/Helpers/LatteFactory.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Helpers;
 
@@ -6,9 +8,7 @@ use Latte;
 use Nette\Bridges\ApplicationLatte\LatteFactory as ILatteFactory;
 
 class LatteFactory implements ILatteFactory {
-
 	public function create(): Latte\Engine {
 		return new Latte\Engine();
 	}
-
 }

--- a/src/Components/Helpers/Request.php
+++ b/src/Components/Helpers/Request.php
@@ -1,13 +1,13 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Helpers;
 
 use Nette\Http\Request as NetteRequest;
 
 final class Request extends NetteRequest {
-
 	public function isSameSite(): bool {
 		return true;
 	}
-
 }

--- a/src/Components/Helpers/RouterStub.php
+++ b/src/Components/Helpers/RouterStub.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Helpers;
 
@@ -6,7 +8,6 @@ use Nette;
 use Nette\Routing\Router;
 
 class RouterStub implements Router {
-
 	public $returnUrl = 'http://localhost/';
 
 	public function match(Nette\Http\IRequest $httpRequest): array {
@@ -16,5 +17,4 @@ class RouterStub implements Router {
 	public function constructUrl(array $params, Nette\Http\UrlScript $urlScript): string {
 		return $this->returnUrl;
 	}
-
 }

--- a/src/Components/Hierarchy.php
+++ b/src/Components/Hierarchy.php
@@ -1,11 +1,12 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components;
 
 use WebChemistry\Testing\Components\Hierarchy\Presenter as HierarchyPresenter;
 
 class Hierarchy {
-
 	/** @var PresenterFactory */
 	private $presenterFactory;
 
@@ -16,5 +17,4 @@ class Hierarchy {
 	public function createHierarchy(string $name): HierarchyPresenter {
 		return new HierarchyPresenter($name, $this->presenterFactory);
 	}
-
 }

--- a/src/Components/Hierarchy.php
+++ b/src/Components/Hierarchy.php
@@ -6,15 +6,15 @@ use WebChemistry\Testing\Components\Hierarchy\Presenter as HierarchyPresenter;
 
 class Hierarchy {
 
-	/** @var Presenter */
-	private $presenterService;
+	/** @var PresenterFactory */
+	private $presenterFactory;
 
 	public function __construct() {
-		$this->presenterService = new Presenter();
+		$this->presenterFactory = new PresenterFactory();
 	}
 
 	public function createHierarchy(string $name): HierarchyPresenter {
-		return new HierarchyPresenter($name, $this->presenterService);
+		return new HierarchyPresenter($name, $this->presenterFactory);
 	}
 
 }

--- a/src/Components/Hierarchy.php
+++ b/src/Components/Hierarchy.php
@@ -7,8 +7,7 @@ namespace WebChemistry\Testing\Components;
 use WebChemistry\Testing\Components\Hierarchy\Presenter as HierarchyPresenter;
 
 class Hierarchy {
-	/** @var PresenterFactory */
-	private $presenterFactory;
+	private PresenterFactory $presenterFactory;
 
 	public function __construct() {
 		$this->presenterFactory = new PresenterFactory();

--- a/src/Components/Hierarchy/Control.php
+++ b/src/Components/Hierarchy/Control.php
@@ -1,16 +1,17 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Hierarchy;
 
+use Nette\Application\UI;
+use Nette\ComponentModel\Container;
 use WebChemistry\Testing\Components\Helpers\Helpers;
 use WebChemistry\Testing\Components\Requests\PresenterRequest;
 use WebChemistry\Testing\Components\Responses\ControlResponse;
 use WebChemistry\Testing\TestException;
-use Nette\ComponentModel\Container;
-use Nette\Application\UI;
 
 class Control {
-
 	/** @var PresenterRequest */
 	protected $request;
 
@@ -27,12 +28,10 @@ class Control {
 	}
 
 	/**
-	 * @param string $name
-	 * @return Control
 	 * @throws TestException
 	 */
 	public function getControl(string $name): Control {
-		$ctrl = $this->control->getComponent($name, TRUE);
+		$ctrl = $this->control->getComponent($name, true);
 		if ($ctrl instanceof UI\Form) {
 			throw new TestException("Component '$name' is form, use getForm instead of getControl.");
 		}
@@ -44,8 +43,6 @@ class Control {
 	}
 
 	/**
-	 * @param string $name
-	 * @return Form
 	 * @throws TestException
 	 */
 	public function getForm(string $name): Form {
@@ -64,10 +61,6 @@ class Control {
 		return $this;
 	}
 
-	/**
-	 * @param string $signal
-	 * @return ControlResponse
-	 */
 	public function sendSignal(string $signal): ControlResponse {
 		$this->request->setSignal($this->control->lookupPath('Nette\Application\IPresenter') . '-' . $signal);
 
@@ -81,5 +74,4 @@ class Control {
 
 		return trim(ob_get_clean());
 	}
-
 }

--- a/src/Components/Hierarchy/Control.php
+++ b/src/Components/Hierarchy/Control.php
@@ -12,11 +12,9 @@ use WebChemistry\Testing\Components\Responses\ControlResponse;
 use WebChemistry\Testing\TestException;
 
 class Control {
-	/** @var PresenterRequest */
-	protected $request;
+	protected PresenterRequest $request;
 
-	/** @var Container */
-	protected $control;
+	protected Container $control;
 
 	public function __construct(PresenterRequest $request, Container $control) {
 		$this->request = $request;

--- a/src/Components/Hierarchy/DomQuery.php
+++ b/src/Components/Hierarchy/DomQuery.php
@@ -2,20 +2,18 @@
 
 /**
  * This file is part of the Nette Tester.
- * Copyright (c) 2009 David Grudl (https://davidgrudl.com)
+ * Copyright (c) 2009 David Grudl (https://davidgrudl.com).
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Hierarchy;
 
 /**
  * DomQuery simplifies querying (X)HTML documents.
  */
-class DomQuery extends \SimpleXMLElement
-{
-	public static function fromHtml(string $html): self
-	{
+class DomQuery extends \SimpleXMLElement {
+	public static function fromHtml(string $html): self {
 		if (!str_contains($html, '<')) {
 			$html = '<body>' . $html;
 		}
@@ -26,11 +24,11 @@ class DomQuery extends \SimpleXMLElement
 		// fix parsing of </ inside scripts
 		$html = preg_replace_callback(
 			'#(<script(?=\s|>)(?:"[^"]*"|\'[^\']*\'|[^"\'>])*+>)(.*?)(</script>)#s',
-			fn(array $m): string => $m[1] . str_replace('</', '<\/', $m[2]) . $m[3],
+			fn (array $m): string => $m[1] . str_replace('</', '<\/', $m[2]) . $m[3],
 			$html,
 		);
 
-		$dom = new \DOMDocument;
+		$dom = new \DOMDocument();
 		$old = libxml_use_internal_errors(true);
 		libxml_clear_errors();
 		$dom->loadHTML($html);
@@ -46,33 +44,30 @@ class DomQuery extends \SimpleXMLElement
 		return simplexml_import_dom($dom, self::class);
 	}
 
-	public static function fromXml(string $xml): self
-	{
+	public static function fromXml(string $xml): self {
 		return simplexml_load_string($xml, self::class);
 	}
 
 	/**
 	 * Returns array of descendants filtered by a selector.
+	 *
 	 * @return DomQuery[]
 	 */
-	public function find(string $selector): array
-	{
+	public function find(string $selector): array {
 		return $this->xpath(self::css2xpath($selector));
 	}
 
 	/**
 	 * Check the current document against a selector.
 	 */
-	public function has(string $selector): bool
-	{
+	public function has(string $selector): bool {
 		return (bool) $this->find($selector);
 	}
 
 	/**
 	 * Transforms CSS expression to XPath.
 	 */
-	public static function css2xpath(string $css): string
-	{
+	public static function css2xpath(string $css): string {
 		$xpath = './/*';
 		preg_match_all(<<<'XX'
 			/

--- a/src/Components/Hierarchy/Form.php
+++ b/src/Components/Hierarchy/Form.php
@@ -12,11 +12,9 @@ use WebChemistry\Testing\Components\Requests\PresenterRequest;
 use WebChemistry\Testing\Components\Responses\FormResponse;
 
 class Form {
-	/** @var PresenterRequest */
-	private $request;
+	private PresenterRequest $request;
 
-	/** @var UI\Form */
-	private $form;
+	private UI\Form $form;
 
 	public function __construct(PresenterRequest $request, UI\Form $form) {
 		$this->request = $request;

--- a/src/Components/Hierarchy/Form.php
+++ b/src/Components/Hierarchy/Form.php
@@ -36,7 +36,7 @@ class Form {
 		return '';
 	}
 
-	public function addFileUpload(string $name, FileUpload $fileUpload) {
+	public function addFileUpload(string $name, FileUpload $fileUpload): void {
 		$this->request->addFileUpload($name, $fileUpload);
 	}
 

--- a/src/Components/Hierarchy/Form.php
+++ b/src/Components/Hierarchy/Form.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Hierarchy;
 
@@ -10,17 +12,12 @@ use WebChemistry\Testing\Components\Requests\PresenterRequest;
 use WebChemistry\Testing\Components\Responses\FormResponse;
 
 class Form {
-
 	/** @var PresenterRequest */
 	private $request;
 
 	/** @var UI\Form */
 	private $form;
 
-	/**
-	 * @param PresenterRequest $request
-	 * @param UI\Form $form
-	 */
 	public function __construct(PresenterRequest $request, UI\Form $form) {
 		$this->request = $request;
 		$this->form = $form;
@@ -61,5 +58,4 @@ class Form {
 
 		return new FormResponse($this->request->send(), $this->getUniqueId());
 	}
-
 }

--- a/src/Components/Hierarchy/Presenter.php
+++ b/src/Components/Hierarchy/Presenter.php
@@ -4,6 +4,7 @@ namespace WebChemistry\Testing\Components\Hierarchy;
 
 use Nette\Application\UI;
 use Nette\Application\IPresenter;
+use WebChemistry\Testing\Components\PresenterFactory;
 use WebChemistry\Testing\Components\Requests\PresenterRequest;
 use WebChemistry\Testing\Components\Responses\PresenterResponse;
 use WebChemistry\Testing\TestException;
@@ -16,21 +17,21 @@ class Presenter {
 	/** @var IPresenter|UI\Presenter */
 	protected $presenter;
 
-	/** @var \WebChemistry\Testing\Components\Presenter */
-	private $presenterService;
+	/** @var PresenterFactory */
+	private $presenterFactory;
 
 	/** @var string */
 	private $name;
 
-	public function __construct(string $name, \WebChemistry\Testing\Components\Presenter $presenterService) {
-		$this->request = new PresenterRequest($presenterService, $presenterService->createPresenter($name), $name);
-		$this->presenter = $presenterService->createPresenter($name);
-		$this->presenterService = $presenterService;
+	public function __construct(string $name, PresenterFactory $presenterFactory) {
+		$this->request = new PresenterRequest($presenterFactory, $presenterFactory->createPresenter($name), $name);
+		$this->presenter = $presenterFactory->createPresenter($name);
+		$this->presenterFactory = $presenterFactory;
 		$this->name = $name;
 	}
 
 	public function cleanup(): void {
-		$this->request = new PresenterRequest($this->presenterService, $this->presenterService->createPresenter($this->name), $this->name);
+		$this->request = new PresenterRequest($this->presenterFactory, $this->presenterFactory->createPresenter($this->name), $this->name);
 	}
 
 	public function getControl(string $name): Control {

--- a/src/Components/Hierarchy/Presenter.php
+++ b/src/Components/Hierarchy/Presenter.php
@@ -12,17 +12,13 @@ use WebChemistry\Testing\Components\Responses\PresenterResponse;
 use WebChemistry\Testing\TestException;
 
 class Presenter {
-	/** @var PresenterRequest */
-	protected $request;
+	protected PresenterRequest $request;
 
-	/** @var IPresenter|UI\Presenter */
-	protected $presenter;
+	protected IPresenter|UI\Presenter $presenter;
 
-	/** @var PresenterFactory */
-	private $presenterFactory;
+	private PresenterFactory $presenterFactory;
 
-	/** @var string */
-	private $name;
+	private string $name;
 
 	public function __construct(string $name, PresenterFactory $presenterFactory) {
 		$this->request = new PresenterRequest($presenterFactory, $presenterFactory->createPresenter($name), $name);

--- a/src/Components/Hierarchy/Presenter.php
+++ b/src/Components/Hierarchy/Presenter.php
@@ -1,16 +1,17 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Hierarchy;
 
-use Nette\Application\UI;
 use Nette\Application\IPresenter;
+use Nette\Application\UI;
 use WebChemistry\Testing\Components\PresenterFactory;
 use WebChemistry\Testing\Components\Requests\PresenterRequest;
 use WebChemistry\Testing\Components\Responses\PresenterResponse;
 use WebChemistry\Testing\TestException;
 
 class Presenter {
-
 	/** @var PresenterRequest */
 	protected $request;
 
@@ -65,23 +66,14 @@ class Presenter {
 		return $this->presenter;
 	}
 
-	/**
-	 * @return PresenterResponse
-	 */
 	public function send(): PresenterResponse {
 		return $this->request->send();
 	}
 
-	/**
-	 * @return string
-	 */
 	public function render(): string {
 		return $this->request->send()->toString();
 	}
 
-	/**
-	 * @return DomQuery
-	 */
 	public function toDomQuery(): DomQuery {
 		return $this->request->send()->toDomQuery();
 	}
@@ -95,5 +87,4 @@ class Presenter {
 
 		return $this->request->send();
 	}
-
 }

--- a/src/Components/PresenterFactory.php
+++ b/src/Components/PresenterFactory.php
@@ -31,8 +31,13 @@ class PresenterFactory {
 
 			$request = new Request(new UrlScript('http://localhost/'));
 			$presenter->injectPrimary(
-				$request, new Response(), null, new RouterStub(), null,
-				null, $this->createTemplateFactory($request)
+				$request,
+				new Response(),
+				null,
+				new RouterStub(),
+				null,
+				null,
+				$this->createTemplateFactory($request)
 			);
 		}
 

--- a/src/Components/PresenterFactory.php
+++ b/src/Components/PresenterFactory.php
@@ -6,6 +6,7 @@ namespace WebChemistry\Testing\Components;
 
 use Latte\Engine;
 use Nette\Application\IPresenter;
+use Nette\Application\IPresenterFactory;
 use Nette\Application\UI;
 use Nette\Bridges\ApplicationLatte\TemplateFactory;
 use Nette\Http\IRequest;
@@ -16,9 +17,22 @@ use WebChemistry\Testing\Components\Helpers\Request;
 use WebChemistry\Testing\Components\Helpers\RouterStub;
 use WebChemistry\Testing\Components\Requests\PresenterRequest;
 
-class PresenterFactory {
+class PresenterFactory implements IPresenterFactory {
 	/** @var callable[] */
 	public array $onCreate = [];
+
+	/**
+	 * Generates and checks presenter class name.
+	 *
+	 * @throws InvalidPresenterException
+	 */
+	public function getPresenterClass(string &$name): string {
+		if (!class_exists($name)) {
+			throw new InvalidPresenterException("Cannot load presenter '$class', class '$class' was not found.");
+		}
+
+		return $name;
+	}
 
 	/**
 	 * @return IPresenter|UI\Presenter
@@ -33,7 +47,7 @@ class PresenterFactory {
 			$presenter->injectPrimary(
 				$request,
 				new Response(),
-				null,
+				$this,
 				new RouterStub(),
 				null,
 				null,

--- a/src/Components/PresenterFactory.php
+++ b/src/Components/PresenterFactory.php
@@ -18,7 +18,7 @@ use WebChemistry\Testing\Components\Requests\PresenterRequest;
 
 class PresenterFactory {
 	/** @var callable[] */
-	public $onCreate = [];
+	public array $onCreate = [];
 
 	/**
 	 * @return IPresenter|UI\Presenter

--- a/src/Components/PresenterFactory.php
+++ b/src/Components/PresenterFactory.php
@@ -14,7 +14,7 @@ use WebChemistry\Testing\Components\Helpers\Request;
 use WebChemistry\Testing\Components\Helpers\RouterStub;
 use WebChemistry\Testing\Components\Requests\PresenterRequest;
 
-class Presenter {
+class PresenterFactory {
 
 	/** @var callable[] */
 	public $onCreate = [];

--- a/src/Components/PresenterFactory.php
+++ b/src/Components/PresenterFactory.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components;
 
@@ -15,12 +17,10 @@ use WebChemistry\Testing\Components\Helpers\RouterStub;
 use WebChemistry\Testing\Components\Requests\PresenterRequest;
 
 class PresenterFactory {
-
 	/** @var callable[] */
 	public $onCreate = [];
 
 	/**
-	 * @param string $class
 	 * @return IPresenter|UI\Presenter
 	 */
 	public function createPresenter(string $class): IPresenter {
@@ -45,6 +45,7 @@ class PresenterFactory {
 
 	/**
 	 * @param string|IPresenter $presenter
+	 *
 	 * @return PresenterRequest
 	 */
 	public function createRequest($presenter) {
@@ -65,5 +66,4 @@ class PresenterFactory {
 
 		return null;
 	}
-
 }

--- a/src/Components/PresenterFactory.php
+++ b/src/Components/PresenterFactory.php
@@ -48,12 +48,7 @@ class PresenterFactory {
 		return $presenter;
 	}
 
-	/**
-	 * @param string|IPresenter $presenter
-	 *
-	 * @return PresenterRequest
-	 */
-	public function createRequest($presenter) {
+	public function createRequest(string|IPresenter $presenter): PresenterRequest {
 		if (!$presenter instanceof IPresenter) {
 			$class = $this->createPresenter($presenter);
 		} else {

--- a/src/Components/Presenters/ControlPresenter.php
+++ b/src/Components/Presenters/ControlPresenter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Presenters;
 
@@ -7,9 +9,8 @@ use Nette\Bridges\ApplicationLatte\Template;
 use Nette\ComponentModel\IComponent;
 
 class ControlPresenter extends Presenter {
-
 	/** @var bool */
-	private $render = FALSE;
+	private $render = false;
 
 	/** @var IComponent */
 	private $control;
@@ -23,7 +24,7 @@ class ControlPresenter extends Presenter {
 	}
 
 	public function setRender() {
-		$this->render = TRUE;
+		$this->render = true;
 	}
 
 	public function startup() {
@@ -39,10 +40,10 @@ class ControlPresenter extends Presenter {
 			$template = $this->getTemplate();
 			$template->setFile(__DIR__ . '/templates/control.latte');
 			$template->name = $this->name;
+
 			return;
 		}
 
 		$this->terminate();
 	}
-
 }

--- a/src/Components/Presenters/ControlPresenter.php
+++ b/src/Components/Presenters/ControlPresenter.php
@@ -9,14 +9,11 @@ use Nette\Bridges\ApplicationLatte\Template;
 use Nette\ComponentModel\IComponent;
 
 class ControlPresenter extends Presenter {
-	/** @var bool */
-	private $render = false;
+	private bool $render = false;
 
-	/** @var IComponent */
-	private $control;
+	private IComponent $control;
 
-	/** @var string */
-	private $name;
+	private string $name;
 
 	public function setControl($name, IComponent $control): void {
 		$this->control = $control;

--- a/src/Components/Presenters/ControlPresenter.php
+++ b/src/Components/Presenters/ControlPresenter.php
@@ -18,23 +18,23 @@ class ControlPresenter extends Presenter {
 	/** @var string */
 	private $name;
 
-	public function setControl($name, IComponent $control) {
+	public function setControl($name, IComponent $control): void {
 		$this->control = $control;
 		$this->name = $name;
 	}
 
-	public function setRender() {
+	public function setRender(): void {
 		$this->render = true;
 	}
 
-	public function startup() {
+	public function startup(): void {
 		parent::startup();
 
 		$this->control->setParent(null);
 		$this->addComponent($this->control, $this->name);
 	}
 
-	public function renderDefault() {
+	public function renderDefault(): void {
 		if ($this->render) {
 			/** @var Template|\stdClass $template */
 			$template = $this->getTemplate();

--- a/src/Components/Presenters/FormPresenter.php
+++ b/src/Components/Presenters/FormPresenter.php
@@ -9,11 +9,9 @@ use Nette\Application\UI\Presenter;
 use Nette\ComponentModel\IComponent;
 
 class FormPresenter extends Presenter {
-	/** @var Form */
-	public $form;
+	public Form $form;
 
-	/** @var string */
-	public $name = 'foo';
+	public string $name = 'foo';
 
 	/** @var callable */
 	public $actionCallback;
@@ -21,8 +19,7 @@ class FormPresenter extends Presenter {
 	/** @var callable */
 	public $renderCallback;
 
-	/** @var string|null */
-	public $file;
+	public ?string $file;
 
 	protected function createComponent(string $name): ?IComponent {
 		if ($this->name === $name) {

--- a/src/Components/Presenters/FormPresenter.php
+++ b/src/Components/Presenters/FormPresenter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Presenters;
 
@@ -7,7 +9,6 @@ use Nette\Application\UI\Presenter;
 use Nette\ComponentModel\IComponent;
 
 class FormPresenter extends Presenter {
-
 	/** @var Form */
 	public $form;
 
@@ -43,8 +44,7 @@ class FormPresenter extends Presenter {
 		}
 
 		$template = $this->getTemplate();
-		$template->setFile($this->file ? : __DIR__ . '/templates/control.latte');
+		$template->setFile($this->file ?: __DIR__ . '/templates/control.latte');
 		$template->name = $this->name;
 	}
-
 }

--- a/src/Components/Requests/BaseRequest.php
+++ b/src/Components/Requests/BaseRequest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Requests;
 
@@ -10,7 +12,6 @@ use WebChemistry\Testing\Components\PresenterFactory;
 use WebChemistry\Testing\Components\Responses\PresenterResponse;
 
 abstract class BaseRequest {
-
 	/** @var array */
 	protected $post = [];
 
@@ -42,7 +43,6 @@ abstract class BaseRequest {
 	// Posts
 
 	/**
-	 * @param array $post
 	 * @return static
 	 */
 	public function setPost(array $post) {
@@ -52,8 +52,6 @@ abstract class BaseRequest {
 	}
 
 	/**
-	 * @param string $name
-	 * @param $value
 	 * @return static
 	 */
 	public function addPost(string $name, $value) {
@@ -63,7 +61,6 @@ abstract class BaseRequest {
 	}
 
 	/**
-	 * @param array $post
 	 * @return static
 	 */
 	public function addPosts(array $post) {
@@ -77,12 +74,13 @@ abstract class BaseRequest {
 	/**
 	 * @param string $name
 	 * @param string $path
+	 *
 	 * @return static
 	 */
 	public function addFile($name, $path) {
 		$this->files[$name] = new FileUpload([
 			'name' => basename($path),
-			'type' => NULL,
+			'type' => null,
 			'size' => filesize($path),
 			'tmp_name' => $path,
 		]);
@@ -92,7 +90,7 @@ abstract class BaseRequest {
 
 	/**
 	 * @param string $name
-	 * @param FileUpload $fileUpload
+	 *
 	 * @return static
 	 */
 	public function addFileUpload($name, FileUpload $fileUpload) {
@@ -102,7 +100,6 @@ abstract class BaseRequest {
 	}
 
 	/**
-	 * @param array $files
 	 * @return static
 	 */
 	public function setFiles(array $files) {
@@ -114,7 +111,6 @@ abstract class BaseRequest {
 	// Params
 
 	/**
-	 * @param array $params
 	 * @return static
 	 */
 	public function setControlParams(array $params) {
@@ -125,7 +121,6 @@ abstract class BaseRequest {
 	}
 
 	/**
-	 * @param array $params
 	 * @return static
 	 */
 	public function setParams(array $params) {
@@ -136,7 +131,7 @@ abstract class BaseRequest {
 
 	/**
 	 * @param string $name
-	 * @param mixed $value
+	 *
 	 * @return static
 	 */
 	public function addParam($name, $value) {
@@ -146,7 +141,6 @@ abstract class BaseRequest {
 	}
 
 	/**
-	 * @param array $params
 	 * @return static
 	 */
 	public function addParams(array $params) {
@@ -157,6 +151,7 @@ abstract class BaseRequest {
 
 	/**
 	 * @param string $action
+	 *
 	 * @return static
 	 */
 	public function setSignal($action) {
@@ -186,7 +181,6 @@ abstract class BaseRequest {
 	}
 
 	/**
-	 * @param IPresenter $presenter
 	 * @return PresenterResponse
 	 */
 	protected function createRequest(IPresenter $presenter) {
@@ -200,5 +194,4 @@ abstract class BaseRequest {
 
 		return $request->send();
 	}
-
 }

--- a/src/Components/Requests/BaseRequest.php
+++ b/src/Components/Requests/BaseRequest.php
@@ -158,7 +158,7 @@ abstract class BaseRequest {
 
 	// Method
 
-	public function setMethod(?string $method) {
+	public function setMethod(?string $method): void {
 		$this->method = $method;
 	}
 

--- a/src/Components/Requests/BaseRequest.php
+++ b/src/Components/Requests/BaseRequest.php
@@ -40,28 +40,19 @@ abstract class BaseRequest {
 
 	// Posts
 
-	/**
-	 * @return static
-	 */
-	public function setPost(array $post) {
+	public function setPost(array $post): static {
 		$this->post = $post;
 
 		return $this;
 	}
 
-	/**
-	 * @return static
-	 */
-	public function addPost(string $name, $value) {
+	public function addPost(string $name, $value): static {
 		$this->post[$name] = $value;
 
 		return $this;
 	}
 
-	/**
-	 * @return static
-	 */
-	public function addPosts(array $post) {
+	public function addPosts(array $post): static {
 		$this->post = array_merge_recursive($this->post, $post);
 
 		return $this;
@@ -69,13 +60,7 @@ abstract class BaseRequest {
 
 	// Files
 
-	/**
-	 * @param string $name
-	 * @param string $path
-	 *
-	 * @return static
-	 */
-	public function addFile($name, $path) {
+	public function addFile(string $name, string $path): static {
 		$this->files[$name] = new FileUpload([
 			'name' => basename($path),
 			'type' => null,
@@ -86,21 +71,13 @@ abstract class BaseRequest {
 		return $this;
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return static
-	 */
-	public function addFileUpload($name, FileUpload $fileUpload) {
+	public function addFileUpload(string $name, FileUpload $fileUpload): static {
 		$this->files[$name] = $fileUpload;
 
 		return $this;
 	}
 
-	/**
-	 * @return static
-	 */
-	public function setFiles(array $files) {
+	public function setFiles(array $files): static {
 		$this->files = $files;
 
 		return $this;
@@ -108,49 +85,32 @@ abstract class BaseRequest {
 
 	// Params
 
-	/**
-	 * @return static
-	 */
-	public function setControlParams(array $params) {
+	public function setControlParams(array $params): static {
 		Helpers::analyzeParams($params, $this->name);
 		$this->params = $params;
 
 		return $this;
 	}
 
-	/**
-	 * @return static
-	 */
-	public function setParams(array $params) {
+	public function setParams(array $params): static {
 		$this->params = $params;
 
 		return $this;
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return static
-	 */
-	public function addParam($name, $value) {
+	public function addParam(string $name, $value): static {
 		$this->params[$name] = $value;
 
 		return $this;
 	}
 
-	/**
-	 * @return static
-	 */
-	public function addParams(array $params) {
+	public function addParams(array $params): static {
 		$this->params = array_merge_recursive($this->params, $params);
 
 		return $this;
 	}
 
-	/**
-	 * @return static
-	 */
-	public function setSignal(?string $action) {
+	public function setSignal(?string $action): static {
 		$this->signal = $action;
 
 		return $this;
@@ -162,10 +122,7 @@ abstract class BaseRequest {
 		$this->method = $method;
 	}
 
-	/**
-	 * @return Request
-	 */
-	protected function createApplicationRequest() {
+	protected function createApplicationRequest(): Request {
 		if ($this->signal !== null) {
 			$this->params['do'] = $this->signal;
 		}
@@ -173,10 +130,7 @@ abstract class BaseRequest {
 		return new Request($this->name, $this->method ?? 'GET', $this->params, $this->post, $this->files, []);
 	}
 
-	/**
-	 * @return PresenterResponse
-	 */
-	protected function createRequest(IPresenter $presenter) {
+	protected function createRequest(IPresenter $presenter): PresenterResponse {
 		$request = $this->presenterFactory->createRequest($presenter);
 
 		$request->setMethod($this->method);

--- a/src/Components/Requests/BaseRequest.php
+++ b/src/Components/Requests/BaseRequest.php
@@ -27,11 +27,9 @@ abstract class BaseRequest {
 	/** @var string */
 	protected $name;
 
-	/** @var string */
-	protected $signal;
+	protected ?string $signal = null;
 
-	/** @var string */
-	protected $method;
+	protected ?string $method = null;
 
 	public function __construct(PresenterFactory $presenterFactory, $name) {
 		$this->presenterFactory = $presenterFactory;
@@ -150,11 +148,9 @@ abstract class BaseRequest {
 	}
 
 	/**
-	 * @param string $action
-	 *
 	 * @return static
 	 */
-	public function setSignal($action) {
+	public function setSignal(?string $action) {
 		$this->signal = $action;
 
 		return $this;
@@ -162,10 +158,7 @@ abstract class BaseRequest {
 
 	// Method
 
-	/**
-	 * @param string $method
-	 */
-	public function setMethod($method) {
+	public function setMethod(?string $method) {
 		$this->method = $method;
 	}
 
@@ -173,11 +166,11 @@ abstract class BaseRequest {
 	 * @return Request
 	 */
 	protected function createApplicationRequest() {
-		if ($this->signal) {
+		if ($this->signal !== null) {
 			$this->params['do'] = $this->signal;
 		}
 
-		return new Request($this->name, $this->method ?: 'GET', $this->params, $this->post, $this->files, []);
+		return new Request($this->name, $this->method ?? 'GET', $this->params, $this->post, $this->files, []);
 	}
 
 	/**

--- a/src/Components/Requests/BaseRequest.php
+++ b/src/Components/Requests/BaseRequest.php
@@ -12,20 +12,15 @@ use WebChemistry\Testing\Components\PresenterFactory;
 use WebChemistry\Testing\Components\Responses\PresenterResponse;
 
 abstract class BaseRequest {
-	/** @var array */
-	protected $post = [];
+	protected array $post = [];
 
-	/** @var array */
-	protected $files = [];
+	protected array $files = [];
 
-	/** @var array */
-	protected $params = [];
+	protected array $params = [];
 
-	/** @var PresenterFactory */
-	protected $presenterFactory;
+	protected PresenterFactory $presenterFactory;
 
-	/** @var string */
-	protected $name;
+	protected string $name;
 
 	protected ?string $signal = null;
 

--- a/src/Components/Requests/BaseRequest.php
+++ b/src/Components/Requests/BaseRequest.php
@@ -6,7 +6,7 @@ use Nette\Application\IPresenter;
 use Nette\Application\Request;
 use Nette\Http\FileUpload;
 use WebChemistry\Testing\Components\Helpers\Helpers;
-use WebChemistry\Testing\Components\Presenter;
+use WebChemistry\Testing\Components\PresenterFactory;
 use WebChemistry\Testing\Components\Responses\PresenterResponse;
 
 abstract class BaseRequest {
@@ -20,8 +20,8 @@ abstract class BaseRequest {
 	/** @var array */
 	protected $params = [];
 
-	/** @var Presenter */
-	protected $presenterService;
+	/** @var PresenterFactory */
+	protected $presenterFactory;
 
 	/** @var string */
 	protected $name;
@@ -32,8 +32,8 @@ abstract class BaseRequest {
 	/** @var string */
 	protected $method;
 
-	public function __construct(Presenter $presenterService, $name) {
-		$this->presenterService = $presenterService;
+	public function __construct(PresenterFactory $presenterFactory, $name) {
+		$this->presenterFactory = $presenterFactory;
 		$this->name = $name;
 	}
 
@@ -190,7 +190,7 @@ abstract class BaseRequest {
 	 * @return PresenterResponse
 	 */
 	protected function createRequest(IPresenter $presenter) {
-		$request = $this->presenterService->createRequest($presenter);
+		$request = $this->presenterFactory->createRequest($presenter);
 
 		$request->setMethod($this->method);
 		$request->setParams($this->params);

--- a/src/Components/Requests/ControlRequest.php
+++ b/src/Components/Requests/ControlRequest.php
@@ -10,11 +10,9 @@ use WebChemistry\Testing\Components\Presenters\ControlPresenter;
 use WebChemistry\Testing\Components\Responses\ControlResponse;
 
 class ControlRequest extends BaseRequest {
-	/** @var IComponent */
-	private $control;
+	private IComponent $control;
 
-	/** @var bool */
-	private $render = true;
+	private bool $render = true;
 
 	public function __construct(PresenterFactory $presenterFactory, IComponent $control, string $name) {
 		parent::__construct($presenterFactory, $name);

--- a/src/Components/Requests/ControlRequest.php
+++ b/src/Components/Requests/ControlRequest.php
@@ -4,7 +4,7 @@ namespace WebChemistry\Testing\Components\Requests;
 
 use Nette\ComponentModel\IComponent;
 use WebChemistry\Testing\Components\Presenters\ControlPresenter;
-use WebChemistry\Testing\Components\Presenter;
+use WebChemistry\Testing\Components\PresenterFactory;
 use WebChemistry\Testing\Components\Responses\ControlResponse;
 
 class ControlRequest extends BaseRequest {
@@ -15,8 +15,8 @@ class ControlRequest extends BaseRequest {
 	/** @var bool */
 	private $render = true;
 
-	public function __construct(Presenter $presenterService, IComponent $control, string $name) {
-		parent::__construct($presenterService, $name);
+	public function __construct(PresenterFactory $presenterFactory, IComponent $control, string $name) {
+		parent::__construct($presenterFactory, $name);
 
 		$this->control = $control;
 	}
@@ -33,7 +33,7 @@ class ControlRequest extends BaseRequest {
 
 	private function createPresenter(): ControlPresenter {
 		/** @var ControlPresenter $presenter */
-		$presenter = $this->presenterService->createPresenter(ControlPresenter::class);
+		$presenter = $this->presenterFactory->createPresenter(ControlPresenter::class);
 
 		$presenter->setControl($this->name, $this->control);
 		if ($this->render) {

--- a/src/Components/Requests/ControlRequest.php
+++ b/src/Components/Requests/ControlRequest.php
@@ -1,14 +1,15 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Requests;
 
 use Nette\ComponentModel\IComponent;
-use WebChemistry\Testing\Components\Presenters\ControlPresenter;
 use WebChemistry\Testing\Components\PresenterFactory;
+use WebChemistry\Testing\Components\Presenters\ControlPresenter;
 use WebChemistry\Testing\Components\Responses\ControlResponse;
 
 class ControlRequest extends BaseRequest {
-
 	/** @var IComponent */
 	private $control;
 
@@ -42,5 +43,4 @@ class ControlRequest extends BaseRequest {
 
 		return $presenter;
 	}
-
 }

--- a/src/Components/Requests/FormRequest.php
+++ b/src/Components/Requests/FormRequest.php
@@ -11,8 +11,7 @@ use WebChemistry\Testing\Components\Responses\FormResponse;
 use WebChemistry\Testing\TestException;
 
 class FormRequest extends BaseRequest {
-	/** @var Form */
-	private $form;
+	private Form $form;
 
 	/** @var callable */
 	private $actionCallback;

--- a/src/Components/Requests/FormRequest.php
+++ b/src/Components/Requests/FormRequest.php
@@ -1,15 +1,16 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Requests;
 
 use Nette\Application\UI\Form;
-use WebChemistry\Testing\Components\Presenters\FormPresenter;
 use WebChemistry\Testing\Components\PresenterFactory;
+use WebChemistry\Testing\Components\Presenters\FormPresenter;
 use WebChemistry\Testing\Components\Responses\FormResponse;
 use WebChemistry\Testing\TestException;
 
 class FormRequest extends BaseRequest {
-
 	/** @var Form */
 	private $form;
 
@@ -43,9 +44,6 @@ class FormRequest extends BaseRequest {
 		return $this;
 	}
 
-	/**
-	 * @return FormResponse
-	 */
 	public function send(): FormResponse {
 		$this->signal = $this->name . '-submit';
 		$this->setMethod('POST');
@@ -68,5 +66,4 @@ class FormRequest extends BaseRequest {
 	public function setSignal($action) {
 		throw new TestException('Cannot set action in form.');
 	}
-
 }

--- a/src/Components/Requests/FormRequest.php
+++ b/src/Components/Requests/FormRequest.php
@@ -4,7 +4,7 @@ namespace WebChemistry\Testing\Components\Requests;
 
 use Nette\Application\UI\Form;
 use WebChemistry\Testing\Components\Presenters\FormPresenter;
-use WebChemistry\Testing\Components\Presenter;
+use WebChemistry\Testing\Components\PresenterFactory;
 use WebChemistry\Testing\Components\Responses\FormResponse;
 use WebChemistry\Testing\TestException;
 
@@ -19,8 +19,8 @@ class FormRequest extends BaseRequest {
 	/** @var callable */
 	private $renderCallback;
 
-	public function __construct(Presenter $presenterService, Form $form, $name) {
-		parent::__construct($presenterService, $name);
+	public function __construct(PresenterFactory $presenterFactory, Form $form, $name) {
+		parent::__construct($presenterFactory, $name);
 
 		$this->form = $form;
 	}
@@ -55,7 +55,7 @@ class FormRequest extends BaseRequest {
 
 	public function render(?string $templateFile = null): FormResponse {
 		/** @var FormPresenter $presenter */
-		$presenter = $this->presenterService->createPresenter(FormPresenter::class);
+		$presenter = $this->presenterFactory->createPresenter(FormPresenter::class);
 		$presenter->name = $this->name;
 		$presenter->form = $this->form;
 		$presenter->file = $templateFile;

--- a/src/Components/Requests/FormRequest.php
+++ b/src/Components/Requests/FormRequest.php
@@ -63,7 +63,7 @@ class FormRequest extends BaseRequest {
 		return new FormResponse($this->createRequest($presenter), $this->name);
 	}
 
-	public function setSignal($action) {
+	public function setSignal(?string $action): static {
 		throw new TestException('Cannot set action in form.');
 	}
 }

--- a/src/Components/Requests/PresenterRequest.php
+++ b/src/Components/Requests/PresenterRequest.php
@@ -10,8 +10,7 @@ use WebChemistry\Testing\Components\Responses\PresenterResponse;
 use WebChemistry\Testing\TestException;
 
 class PresenterRequest extends BaseRequest {
-	/** @var IPresenter */
-	private $presenter;
+	private IPresenter $presenter;
 
 	private ?string $presenterAction = null;
 

--- a/src/Components/Requests/PresenterRequest.php
+++ b/src/Components/Requests/PresenterRequest.php
@@ -13,8 +13,7 @@ class PresenterRequest extends BaseRequest {
 	/** @var IPresenter */
 	private $presenter;
 
-	/** @var string */
-	private $presenterAction;
+	private ?string $presenterAction = null;
 
 	public function __construct(PresenterFactory $presenterFactory, IPresenter $presenter, $name) {
 		parent::__construct($presenterFactory, $name);
@@ -22,7 +21,7 @@ class PresenterRequest extends BaseRequest {
 		$this->presenter = $presenter;
 	}
 
-	public function setControlParams(array $params) {
+	public function setControlParams(array $params): static {
 		throw new TestException('Cannot setControlParams in presenter.');
 	}
 
@@ -33,7 +32,7 @@ class PresenterRequest extends BaseRequest {
 	}
 
 	public function send(): PresenterResponse {
-		if ($this->presenterAction) {
+		if ($this->presenterAction !== null) {
 			$this->params['action'] = $this->presenterAction;
 		}
 		$request = $this->createApplicationRequest();

--- a/src/Components/Requests/PresenterRequest.php
+++ b/src/Components/Requests/PresenterRequest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Requests;
 
@@ -8,7 +10,6 @@ use WebChemistry\Testing\Components\Responses\PresenterResponse;
 use WebChemistry\Testing\TestException;
 
 class PresenterRequest extends BaseRequest {
-
 	/** @var IPresenter */
 	private $presenter;
 
@@ -39,5 +40,4 @@ class PresenterRequest extends BaseRequest {
 
 		return new PresenterResponse($this->presenter->run($request), $this->presenter);
 	}
-
 }

--- a/src/Components/Requests/PresenterRequest.php
+++ b/src/Components/Requests/PresenterRequest.php
@@ -3,7 +3,7 @@
 namespace WebChemistry\Testing\Components\Requests;
 
 use Nette\Application\IPresenter;
-use WebChemistry\Testing\Components\Presenter;
+use WebChemistry\Testing\Components\PresenterFactory;
 use WebChemistry\Testing\Components\Responses\PresenterResponse;
 use WebChemistry\Testing\TestException;
 
@@ -15,8 +15,8 @@ class PresenterRequest extends BaseRequest {
 	/** @var string */
 	private $presenterAction;
 
-	public function __construct(Presenter $presenterService, IPresenter $presenter, $name) {
-		parent::__construct($presenterService, $name);
+	public function __construct(PresenterFactory $presenterFactory, IPresenter $presenter, $name) {
+		parent::__construct($presenterFactory, $name);
 
 		$this->presenter = $presenter;
 	}

--- a/src/Components/Responses/BaseResponse.php
+++ b/src/Components/Responses/BaseResponse.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Responses;
 
@@ -7,8 +9,6 @@ use Nette\Application\UI\Presenter;
 use WebChemistry\Testing\Components\Hierarchy\DomQuery;
 
 abstract class BaseResponse {
-
-	/** @var mixed */
 	public $response;
 
 	/** @var IPresenter|Presenter */
@@ -19,9 +19,6 @@ abstract class BaseResponse {
 		$this->presenter = $presenter;
 	}
 
-	/**
-	 * @return mixed
-	 */
 	public function getResponse() {
 		return $this->response;
 	}
@@ -33,9 +30,6 @@ abstract class BaseResponse {
 		return $this->presenter;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function toString(): string {
 		$source = $this->response->getSource();
 
@@ -45,5 +39,4 @@ abstract class BaseResponse {
 	public function toDomQuery(): DomQuery {
 		return DomQuery::fromHtml($this->toString());
 	}
-
 }

--- a/src/Components/Responses/BaseResponse.php
+++ b/src/Components/Responses/BaseResponse.php
@@ -23,10 +23,7 @@ abstract class BaseResponse {
 		return $this->response;
 	}
 
-	/**
-	 * @return IPresenter|Presenter
-	 */
-	public function getPresenter() {
+	public function getPresenter(): IPresenter|Presenter {
 		return $this->presenter;
 	}
 

--- a/src/Components/Responses/BaseResponse.php
+++ b/src/Components/Responses/BaseResponse.php
@@ -11,8 +11,7 @@ use WebChemistry\Testing\Components\Hierarchy\DomQuery;
 abstract class BaseResponse {
 	public $response;
 
-	/** @var IPresenter|Presenter */
-	public $presenter;
+	public IPresenter|Presenter $presenter;
 
 	public function __construct($response, IPresenter $presenter) {
 		$this->response = $response;

--- a/src/Components/Responses/ControlResponse.php
+++ b/src/Components/Responses/ControlResponse.php
@@ -1,16 +1,16 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Responses;
 
 use Nette\ComponentModel\IComponent;
 
 class ControlResponse extends BaseResponse {
-
 	/** @var string */
 	private $name;
 
 	/**
-	 * @param PresenterResponse $response
 	 * @param string $name
 	 */
 	public function __construct(PresenterResponse $response, $name) {
@@ -22,5 +22,4 @@ class ControlResponse extends BaseResponse {
 	public function getControl(): IComponent {
 		return $this->presenter->getComponent($this->name);
 	}
-
 }

--- a/src/Components/Responses/ControlResponse.php
+++ b/src/Components/Responses/ControlResponse.php
@@ -7,8 +7,7 @@ namespace WebChemistry\Testing\Components\Responses;
 use Nette\ComponentModel\IComponent;
 
 class ControlResponse extends BaseResponse {
-	/** @var string */
-	private $name;
+	private string $name;
 
 	public function __construct(PresenterResponse $response, string $name) {
 		parent::__construct($response->getResponse(), $response->getPresenter());

--- a/src/Components/Responses/ControlResponse.php
+++ b/src/Components/Responses/ControlResponse.php
@@ -10,10 +10,7 @@ class ControlResponse extends BaseResponse {
 	/** @var string */
 	private $name;
 
-	/**
-	 * @param string $name
-	 */
-	public function __construct(PresenterResponse $response, $name) {
+	public function __construct(PresenterResponse $response, string $name) {
 		parent::__construct($response->getResponse(), $response->getPresenter());
 
 		$this->name = $name;

--- a/src/Components/Responses/FormResponse.php
+++ b/src/Components/Responses/FormResponse.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Responses;
 
@@ -7,12 +9,10 @@ use Nette\Forms\Container;
 use Nette\Forms\Control;
 
 class FormResponse extends BaseResponse {
-
 	/** @var string */
 	private $form;
 
 	/**
-	 * @param PresenterResponse $response
 	 * @param string $form
 	 */
 	public function __construct(PresenterResponse $response, $form) {
@@ -42,16 +42,13 @@ class FormResponse extends BaseResponse {
 
 	/**
 	 * Returns the values submitted by the form.
-	 * @param Control[]|null  $controls
+	 *
+	 * @param Control[]|null $controls
 	 */
 	public function getValues(string|object $returnType = Container::Array, ?array $controls = null): object|array {
 		return $this->getForm()->getValues($returnType, $controls);
 	}
 
-	/**
-	 * @param string $path
-	 * @return mixed
-	 */
 	public function getValue(string $path) {
 		$values = $this->getValues(Container::Array);
 		foreach (explode('.', $path) as $item) {
@@ -60,5 +57,4 @@ class FormResponse extends BaseResponse {
 
 		return $values;
 	}
-
 }

--- a/src/Components/Responses/FormResponse.php
+++ b/src/Components/Responses/FormResponse.php
@@ -12,10 +12,7 @@ class FormResponse extends BaseResponse {
 	/** @var string */
 	private $form;
 
-	/**
-	 * @param string $form
-	 */
-	public function __construct(PresenterResponse $response, $form) {
+	public function __construct(PresenterResponse $response, string $form) {
 		parent::__construct($response->getResponse(), $response->getPresenter());
 
 		$this->form = $form;
@@ -24,7 +21,7 @@ class FormResponse extends BaseResponse {
 	/**
 	 * @return false|\Nette\Forms\ISubmitterControl
 	 */
-	public function isSubmitted() {
+	public function isSubmitted(): bool|\Nette\Forms\ISubmitterControl {
 		return $this->getForm()->isSubmitted();
 	}
 

--- a/src/Components/Responses/FormResponse.php
+++ b/src/Components/Responses/FormResponse.php
@@ -9,8 +9,7 @@ use Nette\Forms\Container;
 use Nette\Forms\Control;
 
 class FormResponse extends BaseResponse {
-	/** @var string */
-	private $form;
+	private string $form;
 
 	public function __construct(PresenterResponse $response, string $form) {
 		parent::__construct($response->getResponse(), $response->getPresenter());

--- a/src/Components/Responses/PresenterResponse.php
+++ b/src/Components/Responses/PresenterResponse.php
@@ -1,7 +1,8 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing\Components\Responses;
 
 class PresenterResponse extends BaseResponse {
-
 }

--- a/src/ServiceRegistry.php
+++ b/src/ServiceRegistry.php
@@ -11,11 +11,9 @@ use WebChemistry\Testing\Components\Hierarchy;
 use WebChemistry\Testing\Components\PresenterFactory;
 
 final class ServiceRegistry {
-	/** @var array */
-	private $registry = [];
+	private array $registry = [];
 
-	/** @var array */
-	private $meta = [];
+	private array $meta = [];
 
 	public function __construct() {
 		$this->meta = [

--- a/src/ServiceRegistry.php
+++ b/src/ServiceRegistry.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing;
 
@@ -9,7 +11,6 @@ use WebChemistry\Testing\Components\Hierarchy;
 use WebChemistry\Testing\Components\PresenterFactory;
 
 final class ServiceRegistry {
-
 	/** @var array */
 	private $registry = [];
 
@@ -42,5 +43,4 @@ final class ServiceRegistry {
 
 		return $obj;
 	}
-
 }

--- a/src/ServiceRegistry.php
+++ b/src/ServiceRegistry.php
@@ -6,7 +6,7 @@ use WebChemistry\Testing\Components\Control;
 use WebChemistry\Testing\Components\FileSystem;
 use WebChemistry\Testing\Components\Form;
 use WebChemistry\Testing\Components\Hierarchy;
-use WebChemistry\Testing\Components\Presenter;
+use WebChemistry\Testing\Components\PresenterFactory;
 
 final class ServiceRegistry {
 
@@ -18,7 +18,7 @@ final class ServiceRegistry {
 
 	public function __construct() {
 		$this->meta = [
-			'presenterService' => Presenter::class,
+			'presenterService' => PresenterFactory::class,
 			'formService' => Form::class,
 			'fileSystemService' => FileSystem::class,
 			'hierarchyService' => Hierarchy::class,

--- a/src/Services.php
+++ b/src/Services.php
@@ -6,8 +6,8 @@ use WebChemistry\Testing\Components;
 
 class Services {
 
-	/** @var Components\Presenter */
-	public $presenter;
+	/** @var Components\PresenterFactory */
+	public $presenterFactory;
 
 	/** @var Components\Form */
 	public $form;
@@ -24,7 +24,7 @@ class Services {
 	public function __construct() {
 		$registry = new ServiceRegistry();
 
-		$this->presenter = $registry->get('presenterService');
+		$this->presenterFactory = $registry->get('presenterService');
 		$this->form = $registry->get('formService');
 		$this->fileSystem = $registry->get('fileSystemService');
 		$this->control = $registry->get('controlService');

--- a/src/Services.php
+++ b/src/Services.php
@@ -5,20 +5,15 @@ declare(strict_types=1);
 namespace WebChemistry\Testing;
 
 class Services {
-	/** @var Components\PresenterFactory */
-	public $presenterFactory;
+	public Components\PresenterFactory $presenterFactory;
 
-	/** @var Components\Form */
-	public $form;
+	public Components\Form $form;
 
-	/** @var Components\FileSystem */
-	public $fileSystem;
+	public Components\FileSystem $fileSystem;
 
-	/** @var Components\Control */
-	public $control;
+	public Components\Control $control;
 
-	/** @var Components\Hierarchy */
-	public $hierarchy;
+	public Components\Hierarchy $hierarchy;
 
 	public function __construct() {
 		$registry = new ServiceRegistry();

--- a/src/Services.php
+++ b/src/Services.php
@@ -1,11 +1,10 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing;
 
-use WebChemistry\Testing\Components;
-
 class Services {
-
 	/** @var Components\PresenterFactory */
 	public $presenterFactory;
 
@@ -30,5 +29,4 @@ class Services {
 		$this->control = $registry->get('controlService');
 		$this->hierarchy = $registry->get('hierarchyService');
 	}
-
 }

--- a/src/TUnitTest.php
+++ b/src/TUnitTest.php
@@ -1,11 +1,12 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing;
 
 use WebChemistry\Testing\Components\Hierarchy\DomQuery;
 
 trait TUnitTest {
-
 	/** @var Services */
 	protected $services;
 
@@ -21,19 +22,19 @@ trait TUnitTest {
 	public function assertThrownException(callable $function, string $class, ?string $message = null, $code = null): void {
 		$this->addToAssertionCount(1);
 
-		$e = NULL;
+		$e = null;
 		try {
 			call_user_func($function);
 		} catch (\Exception $e) {
 		}
 
-		if ($e === NULL) {
+		if ($e === null) {
 			$this->fail("$class was expected, but none was thrown");
 		} elseif (!$e instanceof $class) {
 			$this->fail("$class was expected but got " . get_class($e) . ($e->getMessage() ? " ({$e->getMessage()})" : ''));
 		} elseif ($message && $message !== $e->getMessage()) {
 			$this->fail("$class with a message matching {$message} was expected but got {$e->getMessage()}");
-		} elseif ($code !== NULL && $e->getCode() !== $code) {
+		} elseif ($code !== null && $e->getCode() !== $code) {
 			$this->fail("$class with a code {$code} was expected but got {$e->getCode()}");
 		}
 	}
@@ -53,5 +54,4 @@ trait TUnitTest {
 			$this->fail(sprintf('Element %s found in DOM', $selector));
 		}
 	}
-
 }

--- a/src/TUnitTest.php
+++ b/src/TUnitTest.php
@@ -31,7 +31,7 @@ trait TUnitTest {
 		if ($e === null) {
 			$this->fail("$class was expected, but none was thrown");
 		} elseif (!$e instanceof $class) {
-			$this->fail("$class was expected but got " . get_class($e) . ($e->getMessage() ? " ({$e->getMessage()})" : ''));
+			$this->fail("$class was expected but got " . $e::class . ($e->getMessage() ? " ({$e->getMessage()})" : ''));
 		} elseif ($message && $message !== $e->getMessage()) {
 			$this->fail("$class with a message matching {$message} was expected but got {$e->getMessage()}");
 		} elseif ($code !== null && $e->getCode() !== $code) {

--- a/src/TUnitTest.php
+++ b/src/TUnitTest.php
@@ -7,8 +7,7 @@ namespace WebChemistry\Testing;
 use WebChemistry\Testing\Components\Hierarchy\DomQuery;
 
 trait TUnitTest {
-	/** @var Services */
-	protected $services;
+	protected Services $services;
 
 	protected function setUp(): void {
 		$this->services = new Services();

--- a/src/TestException.php
+++ b/src/TestException.php
@@ -1,9 +1,8 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace WebChemistry\Testing;
 
-use RuntimeException;
-
-class TestException extends RuntimeException {
-
+class TestException extends \RuntimeException {
 }

--- a/tests/Support/Helper/FormTester.php
+++ b/tests/Support/Helper/FormTester.php
@@ -1,11 +1,12 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\Support\Helper;
 
 use Nette\Application\UI\Form;
 
 final class FormTester {
-
 	public static function create(): Form {
 		$form = new Form();
 
@@ -15,5 +16,4 @@ final class FormTester {
 
 		return $form;
 	}
-
 }

--- a/tests/Support/Helper/FormTester.php
+++ b/tests/Support/Helper/FormTester.php
@@ -12,7 +12,7 @@ final class FormTester {
 
 		$form->addText('name');
 
-		$form->onSuccess[] = function () {};
+		$form->onSuccess[] = function (): void {};
 
 		return $form;
 	}

--- a/tests/Support/UnitTester.php
+++ b/tests/Support/UnitTester.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Tests\Support;
 
 /**
- * Inherited Methods
+ * Inherited Methods.
+ *
  * @method void wantTo($text)
  * @method void wantToTest($text)
  * @method void execute($callable)
@@ -18,12 +19,11 @@ namespace Tests\Support;
  * @method void pause($vars = [])
  *
  * @SuppressWarnings(PHPMD)
-*/
-class UnitTester extends \Codeception\Actor
-{
-    use _generated\UnitTesterActions;
+ */
+class UnitTester extends \Codeception\Actor {
+	use _generated\UnitTesterActions;
 
-    /**
-     * Define custom actions here
-     */
+	/*
+	 * Define custom actions here
+	 */
 }

--- a/tests/Unit/ControlTest.php
+++ b/tests/Unit/ControlTest.php
@@ -10,7 +10,7 @@ use WebChemistry\Testing\TUnitTest;
 class ControlTest extends \Codeception\Test\Unit {
 	use TUnitTest;
 
-	public function testAnalyzeParams() {
+	public function testAnalyzeParams(): void {
 		$array = [
 			'foo' => 'value',
 			'bar' => [
@@ -29,7 +29,7 @@ class ControlTest extends \Codeception\Test\Unit {
 		], $array);
 	}
 
-	public function testSendParams() {
+	public function testSendParams(): void {
 		$request = $this->services->control->createRequest(new FooControl());
 
 		$request->setControlParams([
@@ -39,7 +39,7 @@ class ControlTest extends \Codeception\Test\Unit {
 		$this->assertSame('bar', $request->send()->getControl()->foo);
 	}
 
-	public function testSendParamsTwice() {
+	public function testSendParamsTwice(): void {
 		$request = $this->services->control->createRequest(new FooControl());
 		$request->setControlParams([
 			'foo' => 'bar',
@@ -54,7 +54,7 @@ class ControlTest extends \Codeception\Test\Unit {
 		$this->assertSame('bar2', $request->send()->getControl()->foo);
 	}
 
-	public function testRenderString() {
+	public function testRenderString(): void {
 		$request = $this->services->control->createRequest(new FooControl());
 		$request->setControlParams([
 			'foo' => 'bar',
@@ -69,7 +69,7 @@ class FooControl extends \Nette\Application\UI\Control {
 	/** @persistent @var string */
 	public $foo = null;
 
-	public function render() {
+	public function render(): void {
 		$this->template->setFile(__DIR__ . '/templates/basic.latte');
 
 		$this->template->param = $this->foo;

--- a/tests/Unit/ControlTest.php
+++ b/tests/Unit/ControlTest.php
@@ -1,13 +1,13 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\Unit;
 
-use WebChemistry\Testing\Components\Control;
 use WebChemistry\Testing\Components\Helpers\Helpers;
 use WebChemistry\Testing\TUnitTest;
 
 class ControlTest extends \Codeception\Test\Unit {
-
 	use TUnitTest;
 
 	public function testAnalyzeParams() {
@@ -61,13 +61,11 @@ class ControlTest extends \Codeception\Test\Unit {
 		]);
 
 		$source = $request->setRender()->send()->toString();
-		$this->assertSame('test bar', trim((string)$source));
+		$this->assertSame('test bar', trim((string) $source));
 	}
-
 }
 
 class FooControl extends \Nette\Application\UI\Control {
-
 	/** @persistent @var string */
 	public $foo = null;
 
@@ -78,5 +76,4 @@ class FooControl extends \Nette\Application\UI\Control {
 
 		$this->template->render();
 	}
-
 }

--- a/tests/Unit/FileSystemTest.php
+++ b/tests/Unit/FileSystemTest.php
@@ -1,11 +1,12 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\Unit;
 
 use WebChemistry\Testing\TUnitTest;
 
 class FileSystemTest extends \Codeception\Test\Unit {
-
 	use TUnitTest;
 
 	public function testRemoveRecursive() {
@@ -50,5 +51,4 @@ class FileSystemTest extends \Codeception\Test\Unit {
 
 		$this->services->fileSystem->removeDirRecursive(__DIR__ . '/temp');
 	}
-
 }

--- a/tests/Unit/FileSystemTest.php
+++ b/tests/Unit/FileSystemTest.php
@@ -9,7 +9,7 @@ use WebChemistry\Testing\TUnitTest;
 class FileSystemTest extends \Codeception\Test\Unit {
 	use TUnitTest;
 
-	public function testRemoveRecursive() {
+	public function testRemoveRecursive(): void {
 		@mkdir(__DIR__ . '/temp');
 		@mkdir(__DIR__ . '/temp/temp2');
 		@touch(__DIR__ . '/temp/file.txt');
@@ -19,7 +19,7 @@ class FileSystemTest extends \Codeception\Test\Unit {
 		$this->assertTrue(!file_exists(__DIR__ . '/temp'));
 	}
 
-	public function testFileCount() {
+	public function testFileCount(): void {
 		@mkdir(__DIR__ . '/temp');
 		@mkdir(__DIR__ . '/temp/temp2');
 		@touch(__DIR__ . '/temp/file.txt');
@@ -30,7 +30,7 @@ class FileSystemTest extends \Codeception\Test\Unit {
 		$this->services->fileSystem->removeDirRecursive(__DIR__ . '/temp');
 	}
 
-	public function testDirCount() {
+	public function testDirCount(): void {
 		@mkdir(__DIR__ . '/temp');
 		@mkdir(__DIR__ . '/temp/temp2');
 		@touch(__DIR__ . '/temp/file.txt');
@@ -41,7 +41,7 @@ class FileSystemTest extends \Codeception\Test\Unit {
 		$this->services->fileSystem->removeDirRecursive(__DIR__ . '/temp');
 	}
 
-	public function testItemCount() {
+	public function testItemCount(): void {
 		@mkdir(__DIR__ . '/temp');
 		@mkdir(__DIR__ . '/temp/temp2');
 		@touch(__DIR__ . '/temp/file.txt');

--- a/tests/Unit/FormTest.php
+++ b/tests/Unit/FormTest.php
@@ -12,7 +12,7 @@ use WebChemistry\Testing\TUnitTest;
 class FormTest extends \Codeception\Test\Unit {
 	use TUnitTest;
 
-	public function testSend() {
+	public function testSend(): void {
 		$sender = $this->services->form->createRequest(FormTester::create());
 		$sender->addPost('name', 'foo');
 		$response = $sender->send();
@@ -22,7 +22,7 @@ class FormTest extends \Codeception\Test\Unit {
 		$this->assertSame('foo', $response->getForm()->getValues()['name']);
 	}
 
-	public function testGetValue() {
+	public function testGetValue(): void {
 		$sender = $this->services->form->createRequest(FormTester::create());
 		$sender->addPost('name', 'foo');
 		$response = $sender->send();
@@ -30,17 +30,17 @@ class FormTest extends \Codeception\Test\Unit {
 		$this->assertSame('foo', $response->getValue('name'));
 	}
 
-	public function testRequestRender() {
+	public function testRequestRender(): void {
 		$request = $this->services->form->createRequest(FormTester::create());
 		$response = $request->render();
 
 		$this->assertFalse($response->isSubmitted());
 	}
 
-	public function testActionCallback() {
-		$request = $this->services->form->createRequest(FormTester::create())->setActionCallback(function (Form $form) {
+	public function testActionCallback(): void {
+		$request = $this->services->form->createRequest(FormTester::create())->setActionCallback(function (Form $form): void {
 			$form->addText('action');
-		})->setRenderCallback(function (Form $form) {
+		})->setRenderCallback(function (Form $form): void {
 			$form->addText('render');
 		});
 		$response = $request->render();

--- a/tests/Unit/FormTest.php
+++ b/tests/Unit/FormTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\Unit;
 
@@ -8,7 +10,6 @@ use WebChemistry\Testing\Components\Responses\FormResponse;
 use WebChemistry\Testing\TUnitTest;
 
 class FormTest extends \Codeception\Test\Unit {
-
 	use TUnitTest;
 
 	public function testSend() {
@@ -49,5 +50,4 @@ class FormTest extends \Codeception\Test\Unit {
 		$this->assertTrue(isset($form['action']));
 		$this->assertTrue(isset($form['render']));
 	}
-
 }

--- a/tests/Unit/HierarchyTest.php
+++ b/tests/Unit/HierarchyTest.php
@@ -12,39 +12,39 @@ use WebChemistry\Testing\TUnitTest;
 class HierarchyTest extends \Codeception\Test\Unit {
 	use TUnitTest;
 
-	protected function _before() {
+	protected function _before(): void {
 	}
 
-	protected function _after() {
+	protected function _after(): void {
 	}
 
-	public function testSendPresenter() {
+	public function testSendPresenter(): void {
 		$hierarchy = $this->services->hierarchy->createHierarchy(HiPresenter::class);
 
 		$this->assertSame('Test', $hierarchy->send()->toString());
 	}
 
-	public function testSendPresenterAction() {
+	public function testSendPresenterAction(): void {
 		$hierarchy = $this->services->hierarchy->createHierarchy(HiPresenter::class);
 		$hierarchy->setAction('foo');
 
 		$this->assertSame('Test Foo action', $hierarchy->send()->toString());
 	}
 
-	public function testSendPresenterHandle() {
+	public function testSendPresenterHandle(): void {
 		$hierarchy = $this->services->hierarchy->createHierarchy(HiPresenter::class);
 		$hierarchy->addParams(['param' => 'handle']);
 
 		$this->assertSame('Test handle', $hierarchy->sendSignal('test')->toString());
 	}
 
-	public function testPresenterGetControl() {
+	public function testPresenterGetControl(): void {
 		$hierarchy = $this->services->hierarchy->createHierarchy(HiPresenter::class);
 
 		$this->assertInstanceOf(MyControl::class, $hierarchy->getControl('control')->getObject());
 	}
 
-	public function testControlSignal() {
+	public function testControlSignal(): void {
 		$hierarchy = $this->services->hierarchy->createHierarchy(HiPresenter::class);
 
 		$response = $hierarchy->getControl('control')->addParams(['param2' => 'test'])->sendSignal('test');
@@ -54,28 +54,30 @@ class HierarchyTest extends \Codeception\Test\Unit {
 		$this->assertSame('handle-control-test', $response->getControl()->param);
 	}
 
-	public function testControlPersistentParam() {
+	public function testControlPersistentParam(): void {
 		$hierarchy = $this->services->hierarchy->createHierarchy(HiPresenter::class);
 		$hierarchy->getControl('control')->addParams(['param' => 'test']);
 
 		$this->assertSame('Test test', $hierarchy->send()->toString());
 	}
 
-	public function testControlRender() {
+	public function testControlRender(): void {
 		$hierarchy = $this->services->hierarchy->createHierarchy(HiPresenter::class);
 		$hierarchy->getControl('control')->addParams(['param' => 'foo']);
 
 		$this->assertSame('foo', $hierarchy->getControl('control')->render());
 	}
 
-	public function testSubControlRender() {
+	public function testSubControlRender(): void {
 		$hierarchy = $this->services->hierarchy->createHierarchy(HiPresenter::class);
 
-		$this->assertSame('foo',
-			$hierarchy->getControl('control')->getControl('control')->addParams(['param' => 'foo'])->render());
+		$this->assertSame(
+			'foo',
+			$hierarchy->getControl('control')->getControl('control')->addParams(['param' => 'foo'])->render()
+		);
 	}
 
-	public function testRenderPresenterForm() {
+	public function testRenderPresenterForm(): void {
 		$hierarchy = $this->services->hierarchy->createHierarchy(HiPresenter::class);
 		$hierarchy->setAction('form')->render();
 
@@ -83,7 +85,7 @@ class HierarchyTest extends \Codeception\Test\Unit {
 		$this->assertTrue($dom->has('form#frm-form'));
 	}
 
-	public function testSendForm() {
+	public function testSendForm(): void {
 		$hierarchy = $this->services->hierarchy->createHierarchy(HiPresenter::class)->setAction('form');
 
 		$response = $hierarchy->getForm('form')->setValues([
@@ -100,20 +102,20 @@ class HierarchyTest extends \Codeception\Test\Unit {
 }
 
 class HiPresenter extends Presenter {
-	public function actionDefault() {
+	public function actionDefault(): void {
 		$this->template->setFile(__DIR__ . '/templates/hierarchy.latte');
 	}
 
-	public function actionFoo() {
+	public function actionFoo(): void {
 		$this->template->setFile(__DIR__ . '/templates/hierarchy.latte');
 		$this->template->param = 'Foo action';
 	}
 
-	public function actionForm() {
+	public function actionForm(): void {
 		$this->template->setFile(__DIR__ . '/templates/hierarchy-form.latte');
 	}
 
-	public function handleTest($param) {
+	public function handleTest($param): void {
 		$this->template->param = $param;
 	}
 
@@ -126,7 +128,7 @@ class HiPresenter extends Presenter {
 
 		$form->addText('name', 'Name');
 
-		$form->onSuccess[] = function () {};
+		$form->onSuccess[] = function (): void {};
 
 		return $form;
 	}
@@ -136,7 +138,7 @@ class MyControl extends Control {
 	/** @persistent */
 	public $param;
 
-	public function render() {
+	public function render(): void {
 		$this->template->setFile(__DIR__ . '/templates/control.latte');
 
 		$this->template->param = $this->param;
@@ -148,7 +150,7 @@ class MyControl extends Control {
 		return new self();
 	}
 
-	public function handleTest($param2) {
+	public function handleTest($param2): void {
 		$this->param = 'handle-control-' . $param2;
 		$this->template->param = $this->param;
 	}

--- a/tests/Unit/HierarchyTest.php
+++ b/tests/Unit/HierarchyTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\Unit;
 
@@ -8,7 +10,6 @@ use Nette\Application\UI\Presenter;
 use WebChemistry\Testing\TUnitTest;
 
 class HierarchyTest extends \Codeception\Test\Unit {
-
 	use TUnitTest;
 
 	protected function _before() {
@@ -99,7 +100,6 @@ class HierarchyTest extends \Codeception\Test\Unit {
 }
 
 class HiPresenter extends Presenter {
-
 	public function actionDefault() {
 		$this->template->setFile(__DIR__ . '/templates/hierarchy.latte');
 	}
@@ -130,11 +130,9 @@ class HiPresenter extends Presenter {
 
 		return $form;
 	}
-
 }
 
 class MyControl extends Control {
-
 	/** @persistent */
 	public $param;
 
@@ -154,5 +152,4 @@ class MyControl extends Control {
 		$this->param = 'handle-control-' . $param2;
 		$this->template->param = $this->param;
 	}
-
 }

--- a/tests/Unit/PresenterTest.php
+++ b/tests/Unit/PresenterTest.php
@@ -11,13 +11,13 @@ use WebChemistry\Testing\TUnitTest;
 class PresenterTest extends \Codeception\Test\Unit {
 	use TUnitTest;
 
-	protected function _before() {
+	protected function _before(): void {
 	}
 
-	protected function _after() {
+	protected function _after(): void {
 	}
 
-	public function testCreatePresenter() {
+	public function testCreatePresenter(): void {
 		$this->assertInstanceOf(MyPresenter::class, $this->services->presenterFactory->createPresenter(MyPresenter::class));
 		$this->assertNotSame(
 			$this->services->presenterFactory->createPresenter(MyPresenter::class),
@@ -27,7 +27,7 @@ class PresenterTest extends \Codeception\Test\Unit {
 }
 
 class MyPresenter extends Presenter {
-	public function actionDefault() {
+	public function actionDefault(): void {
 		$this->sendResponse(new TextResponse('test'));
 	}
 }

--- a/tests/Unit/PresenterTest.php
+++ b/tests/Unit/PresenterTest.php
@@ -18,10 +18,10 @@ class PresenterTest extends \Codeception\Test\Unit {
 	}
 
 	public function testCreatePresenter() {
-		$this->assertInstanceOf(MyPresenter::class, $this->services->presenter->createPresenter(MyPresenter::class));
+		$this->assertInstanceOf(MyPresenter::class, $this->services->presenterFactory->createPresenter(MyPresenter::class));
 		$this->assertNotSame(
-			$this->services->presenter->createPresenter(MyPresenter::class),
-			$this->services->presenter->createPresenter(MyPresenter::class)
+			$this->services->presenterFactory->createPresenter(MyPresenter::class),
+			$this->services->presenterFactory->createPresenter(MyPresenter::class)
 		);
 	}
 

--- a/tests/Unit/PresenterTest.php
+++ b/tests/Unit/PresenterTest.php
@@ -1,14 +1,14 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\Unit;
 
 use Nette\Application\Responses\TextResponse;
 use Nette\Application\UI\Presenter;
-use WebChemistry\Testing\Components\Responses\PresenterResponse;
 use WebChemistry\Testing\TUnitTest;
 
 class PresenterTest extends \Codeception\Test\Unit {
-
 	use TUnitTest;
 
 	protected function _before() {
@@ -24,15 +24,10 @@ class PresenterTest extends \Codeception\Test\Unit {
 			$this->services->presenterFactory->createPresenter(MyPresenter::class)
 		);
 	}
-
 }
 
 class MyPresenter extends Presenter {
-
 	public function actionDefault() {
 		$this->sendResponse(new TextResponse('test'));
 	}
-
-
-
 }


### PR DESCRIPTION
https://github.com/nette/application/commit/850ab85554db7ab988ffe149f06117f418a4b68a moved link generation to a new LinkGenerator class that must be instantiated or creating links will fail:

    Unable to create link to other presenter, service PresenterFactory or Router has not been set.

In order for LinkGenerator to be instantiated, we need to pass a IPresenterFactory when instantiating a Presenter.
Let’s make our PresenterFactory trivially implement the interface so that it can be used.

Also apply some cleanups.
